### PR TITLE
Store RandomState on model to seed randomness properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.py[cod]
 *.o
 *.so
+.eggs
+build
+*.egg-info

--- a/source-cpp/pyBKT/generate/random_model_uni.py
+++ b/source-cpp/pyBKT/generate/random_model_uni.py
@@ -1,8 +1,7 @@
-import random
 import numpy as np
 from pyBKT.util import dirrnd
 
-def random_model_uni(num_resources=None, num_subparts=None, trans_prior=None, given_notknow_prior=None, given_know_prior=None, pi_0_prior=None):
+def random_model_uni(num_resources=None, num_subparts=None, trans_prior=None, given_notknow_prior=None, given_know_prior=None, pi_0_prior=None, rand=np.random):
 
     if num_resources is None: num_resources = 1
     if num_subparts is None: num_subparts = 1
@@ -16,24 +15,24 @@ def random_model_uni(num_resources=None, num_subparts=None, trans_prior=None, gi
     if pi_0_prior is None:
         pi_0_prior = np.array([[100], [1]])
 
-    As = dirrnd.dirrnd(trans_prior)
-    given_notknow = dirrnd.dirrnd(given_notknow_prior)
-    given_know = dirrnd.dirrnd(given_know_prior)
+    As = dirrnd.dirrnd(trans_prior, rand)
+    given_notknow = dirrnd.dirrnd(given_notknow_prior, rand)
+    given_know = dirrnd.dirrnd(given_know_prior, rand)
     #emissions = np.dstack((given_notknow.reshape((num_subparts, 2, 1)), given_know.reshape((num_subparts, 2, 1))))
     emissions = np.stack((np.transpose(given_notknow.reshape((2, num_subparts))), np.transpose(given_know.reshape((2, num_subparts)))), axis=1)
-    pi_0 = dirrnd.dirrnd(pi_0_prior)
+    pi_0 = dirrnd.dirrnd(pi_0_prior, rand)
 
     modelstruct = {}
-    modelstruct['prior'] = random.random()
-    As[:, 1, 0] = np.random.rand(num_resources) * 0.40
+    modelstruct['prior'] = rand.random()
+    As[:, 1, 0] = rand.rand(num_resources) * 0.40
     As[:, 1, 1] = 1 - As[:, 1, 0]
     As[:, 0, 1] = 0
     As[:, 0, 0] = 1
     modelstruct['learns'] = As[:, 1, 0]
     modelstruct['forgets'] = As[:, 0, 1]
-    given_notknow[1, :] = np.random.rand(num_subparts) * 0.40
+    given_notknow[1, :] = rand.rand(num_subparts) * 0.40
     modelstruct['guesses'] = given_notknow[1, :]
-    given_know[0, :] = np.random.rand(num_subparts) * 0.30
+    given_know[0, :] = rand.rand(num_subparts) * 0.30
     modelstruct['slips'] = given_know[0, :]
 
     modelstruct['As'] = As

--- a/source-cpp/pyBKT/models/Model.py
+++ b/source-cpp/pyBKT/models/Model.py
@@ -403,10 +403,10 @@ class Model:
         best_model = None
 
         for i in range(num_fit_initializations):
-            fitmodel = random_model_uni.random_model_uni(num_learns, num_gs)
+            fitmodel = random_model_uni.random_model_uni(num_learns, num_gs, rand=self.rand)
             optional_args = {'fixed': {}}
             if forgets:
-                fitmodel["forgets"] = np.random.uniform(size = fitmodel["forgets"].shape)
+                fitmodel["forgets"] = self.rand.uniform(size = fitmodel["forgets"].shape)
             if self.model_type[Model.MODELS_BKT.index('multiprior')]:
                 fitmodel["prior"] = 0
             if self.manual_param_init and skill in self.fit_model:
@@ -496,6 +496,10 @@ class Model:
         else:
             setattr(self, params, args)
             self.keep[params] = keep
+        
+        # Update RandomState if seed is one of the parameters to update
+        if 'seed' in params:
+            setattr(self, 'rand', np.random.RandomState(self.seed))
 
     def _update_defaults(self, defaults):
         """ Update the default column names. """

--- a/source-cpp/pyBKT/models/Model.py
+++ b/source-cpp/pyBKT/models/Model.py
@@ -29,7 +29,7 @@ class Model:
                 'defaults': None,
                 'parallel': True,
                 'skills': '.*',
-                'seed': random.randint(0, 1e8),
+                'seed': lambda: random.randint(0, 1e8),
                 'folds': 5,
                 'forgets': False,
                 'fixed': None,
@@ -489,7 +489,8 @@ class Model:
         if isinstance(args, dict):
             for param in params:
                 if param not in args and (param not in self.keep or not self.keep[param]):
-                    setattr(self, param, Model.DEFAULTS[param])
+                    arg = Model.DEFAULTS[param]
+                    setattr(self, param, arg() if callable(arg) else arg) # Allow random seed to differ between models
                 elif param in args:
                     setattr(self, param, args[param])
                 self.keep[param] = keep

--- a/source-cpp/pyBKT/util/crossvalidate.py
+++ b/source-cpp/pyBKT/util/crossvalidate.py
@@ -103,13 +103,15 @@ def fix_data_specified(data, label, count):
     
     return training_data, testing_data
 
+# TODO: Rename seed to 'rand' in next major version
 def crossvalidate(model, data, skill, folds, metric, seed, use_folds=False):
 
     num_learns = len(data["resource_names"]) if "resource_names" in data else 1
     num_gs = len(data["gs_names"]) if "gs_names" in data else num_gs
 
     # create random permutation to act as indices for folds for crossvalidation
-    shuffle = np.random.RandomState(seed=seed).permutation(len(data["starts"]))
+    # TODO: Remove interoperability between int and RandomState in next major version
+    shuffle = (np.random.RandomState(seed=seed) if isinstance(seed, int) else seed).permutation(len(data["starts"]))
     all_true, all_pred = [], []
     metrics = np.zeros((len(metric), ))
 

--- a/source-cpp/pyBKT/util/dirrnd.py
+++ b/source-cpp/pyBKT/util/dirrnd.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-def dirrnd(alphavec):
+def dirrnd(alphavec, rand=np.random):
     dimsum = 1
     if(alphavec.ndim == 3 or alphavec.ndim == 2): dimsum = alphavec.ndim - 2
-    a = np.random.gamma(alphavec, 1)
+    a = rand.gamma(alphavec, 1)
     temp = np.sum(a, axis=dimsum, keepdims=True)
     a = a / np.sum(a, axis=dimsum, keepdims=True)
     return(a)

--- a/source-py/pyBKT/generate/random_model_uni.py
+++ b/source-py/pyBKT/generate/random_model_uni.py
@@ -1,8 +1,7 @@
-import random
 import numpy as np
 from pyBKT.util import dirrnd
 
-def random_model_uni(num_resources=None, num_subparts=None, trans_prior=None, given_notknow_prior=None, given_know_prior=None, pi_0_prior=None):
+def random_model_uni(num_resources=None, num_subparts=None, trans_prior=None, given_notknow_prior=None, given_know_prior=None, pi_0_prior=None, rand=np.random):
 
     if num_resources is None: num_resources = 1
     if num_subparts is None: num_subparts = 1
@@ -16,24 +15,24 @@ def random_model_uni(num_resources=None, num_subparts=None, trans_prior=None, gi
     if pi_0_prior is None:
         pi_0_prior = np.array([[100], [1]])
 
-    As = dirrnd.dirrnd(trans_prior)
-    given_notknow = dirrnd.dirrnd(given_notknow_prior)
-    given_know = dirrnd.dirrnd(given_know_prior)
+    As = dirrnd.dirrnd(trans_prior, rand)
+    given_notknow = dirrnd.dirrnd(given_notknow_prior, rand)
+    given_know = dirrnd.dirrnd(given_know_prior, rand)
     #emissions = np.dstack((given_notknow.reshape((num_subparts, 2, 1)), given_know.reshape((num_subparts, 2, 1))))
     emissions = np.stack((np.transpose(given_notknow.reshape((2, num_subparts))), np.transpose(given_know.reshape((2, num_subparts)))), axis=1)
-    pi_0 = dirrnd.dirrnd(pi_0_prior)
+    pi_0 = dirrnd.dirrnd(pi_0_prior, rand)
 
     modelstruct = {}
-    modelstruct['prior'] = random.random()
-    As[:, 1, 0] = np.random.rand(num_resources) * 0.40
+    modelstruct['prior'] = rand.random()
+    As[:, 1, 0] = rand.rand(num_resources) * 0.40
     As[:, 1, 1] = 1 - As[:, 1, 0]
     As[:, 0, 1] = 0
     As[:, 0, 0] = 1
     modelstruct['learns'] = As[:, 1, 0]
     modelstruct['forgets'] = As[:, 0, 1]
-    given_notknow[1, :] = np.random.rand(num_subparts) * 0.40
+    given_notknow[1, :] = rand.rand(num_subparts) * 0.40
     modelstruct['guesses'] = given_notknow[1, :]
-    given_know[0, :] = np.random.rand(num_subparts) * 0.30
+    given_know[0, :] = rand.rand(num_subparts) * 0.30
     modelstruct['slips'] = given_know[0, :]
 
     modelstruct['As'] = As

--- a/source-py/pyBKT/models/Model.py
+++ b/source-py/pyBKT/models/Model.py
@@ -403,10 +403,10 @@ class Model:
         best_model = None
 
         for i in range(num_fit_initializations):
-            fitmodel = random_model_uni.random_model_uni(num_learns, num_gs)
+            fitmodel = random_model_uni.random_model_uni(num_learns, num_gs, rand=self.rand)
             optional_args = {'fixed': {}}
             if forgets:
-                fitmodel["forgets"] = np.random.uniform(size = fitmodel["forgets"].shape)
+                fitmodel["forgets"] = self.rand.uniform(size = fitmodel["forgets"].shape)
             if self.model_type[Model.MODELS_BKT.index('multiprior')]:
                 fitmodel["prior"] = 0
             if self.manual_param_init and skill in self.fit_model:
@@ -496,6 +496,10 @@ class Model:
         else:
             setattr(self, params, args)
             self.keep[params] = keep
+        
+        # Update RandomState if seed is one of the parameters to update
+        if 'seed' in params:
+            setattr(self, 'rand', np.random.RandomState(self.seed))
 
     def _update_defaults(self, defaults):
         """ Update the default column names. """

--- a/source-py/pyBKT/models/Model.py
+++ b/source-py/pyBKT/models/Model.py
@@ -29,7 +29,7 @@ class Model:
                 'defaults': None,
                 'parallel': True,
                 'skills': '.*',
-                'seed': random.randint(0, 1e8),
+                'seed': lambda: random.randint(0, 1e8),
                 'folds': 5,
                 'forgets': False,
                 'fixed': None,
@@ -489,7 +489,8 @@ class Model:
         if isinstance(args, dict):
             for param in params:
                 if param not in args and (param not in self.keep or not self.keep[param]):
-                    setattr(self, param, Model.DEFAULTS[param])
+                    arg = Model.DEFAULTS[param]
+                    setattr(self, param, arg() if callable(arg) else arg) # Allow random seed to differ between models
                 elif param in args:
                     setattr(self, param, args[param])
                 self.keep[param] = keep

--- a/source-py/pyBKT/util/crossvalidate.py
+++ b/source-py/pyBKT/util/crossvalidate.py
@@ -103,13 +103,15 @@ def fix_data_specified(data, label, count):
     
     return training_data, testing_data
 
+# TODO: Rename seed to 'rand' in next major version
 def crossvalidate(model, data, skill, folds, metric, seed, use_folds=False):
 
     num_learns = len(data["resource_names"]) if "resource_names" in data else 1
     num_gs = len(data["gs_names"]) if "gs_names" in data else num_gs
 
     # create random permutation to act as indices for folds for crossvalidation
-    shuffle = np.random.RandomState(seed=seed).permutation(len(data["starts"]))
+    # TODO: Remove interoperability between int and RandomState in next major version
+    shuffle = (np.random.RandomState(seed=seed) if isinstance(seed, int) else seed).permutation(len(data["starts"]))
     all_true, all_pred = [], []
     metrics = np.zeros((len(metric), ))
 

--- a/source-py/pyBKT/util/dirrnd.py
+++ b/source-py/pyBKT/util/dirrnd.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-def dirrnd(alphavec):
+def dirrnd(alphavec, rand=np.random):
     dimsum = 1
     if(alphavec.ndim == 3 or alphavec.ndim == 2): dimsum = alphavec.ndim - 2
-    a = np.random.gamma(alphavec, 1)
+    a = rand.gamma(alphavec, 1)
     temp = np.sum(a, axis=dimsum, keepdims=True)
     a = a / np.sum(a, axis=dimsum, keepdims=True)
     return(a)


### PR DESCRIPTION
Closes #39.

Adds a `rand` parameter holding the unique, seeded `np.random.RandomState` to the model. If the seed is updated, the `RandomState` is remade with the new seeded value.

All changes were made to be interoperable such that the version can either be bumped as a minor or major. If to be a new major version, the comments should be removed and the behavior hard changed.

I haven't tested this yet as the computer I would normally use is currently experiencing a load. The model should fit fine; however, I am slightly concerned on whether the seed needs to be reset during `crossvalidate` in the model. Most likely, this should be removed; however, I will do so once I am able to actually test everything myself.