### PR TITLE
fix: Convert 1e8 to int in Model.py

### DIFF
--- a/source-py/pyBKT/models/Model.py
+++ b/source-py/pyBKT/models/Model.py
@@ -29,7 +29,7 @@ class Model:
                 'defaults': None,
                 'parallel': True,
                 'skills': '.*',
-                'seed': lambda: random.randint(0, 1e8),
+                'seed': lambda: random.randint(0, int(1e8)),
                 'folds': 5,
                 'forgets': False,
                 'fixed': None,


### PR DESCRIPTION
A version of python later than the tutorial notebook checks whether arguments passed to randint are actually integers, which 1e8 is not. (Or well, calling `random.randint` with floats just doesn't work anymore.)

This is what I get in the notebook:

![image](https://github.com/CAHLR/pyBKT/assets/72065191/36ae5bca-fc9c-4bcb-908f-0e29a86b8ec7)

This is what I get in the console:

```py
Python 3.12.0 | packaged by conda-forge | (main, Oct  3 2023, 08:43:22) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import random
>>> random.randint(0, 1e8)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tijl/miniconda3/envs/maspro/lib/python3.12/random.py", line 336, in randint
    return self.randrange(a, b+1)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tijl/miniconda3/envs/maspro/lib/python3.12/random.py", line 312, in randrange
    istop = _index(stop)
            ^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
>>> random.random() * 1e8
66825182.1552985
>>> random.random() * 1e8
60270388.95157865
>>> 1e8
100000000.0
>>> random.randint(0, int(1e8))
95989487
```

