### PR TITLE
fix: Convert 1e8 to int in Model.py

### DIFF
--- a/source-cpp/pyBKT/models/Model.py
+++ b/source-cpp/pyBKT/models/Model.py
@@ -29,7 +29,7 @@ class Model:
                 'defaults': None,
                 'parallel': True,
                 'skills': '.*',
-                'seed': lambda: random.randint(0, 1e8),
+                'seed': lambda: random.randint(0, int(1e8)),
                 'folds': 5,
                 'forgets': False,
                 'fixed': None,


### PR DESCRIPTION
Fixed Convert 1e8 to int as for the commit d4799ba in the original repo for the file [Model.py](source-cpp/pyBKT/models/Model.py)